### PR TITLE
fix: extend/duplicate .widget-title and .accent-header styles (#1470)

### DIFF
--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -71,6 +71,7 @@ function newspack_joseph_custom_colors_css() {
 		$theme_css .= '
 			#colophon,
 			#colophon .widget-title,
+			#colophon .widgettitle,
 			#colophon .social-navigation a {
 				color: ' . esc_html( $footer_color_contrast ) . ';
 			}

--- a/newspack-joseph/inc/child-typography.php
+++ b/newspack-joseph/inc/child-typography.php
@@ -35,6 +35,7 @@ function newspack_joseph_custom_typography_css() {
 			.widget,
 			.widget-title.accent-header,
 			.accent-header,
+			.widgettitle,
 			.wp-block-button .wp-block-button__link,
 			.entry .article-section-title,
 			button,
@@ -74,6 +75,7 @@ function newspack_joseph_custom_typography_css() {
 	if ( true === get_theme_mod( 'accent_allcaps', true ) ) {
 		$css_blocks        .= '
 			.accent-header,
+			#secondary .widgettitle,
 			.article-section-title {
 				text-transform: uppercase;
 			}

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -102,6 +102,7 @@ figcaption,
 .widget,
 .widget-title.accent-header,
 .accent-header,
+.widgettitle,
 .wp-block-button__link,
 div.wp-block-file,
 div.wp-block-file .wp-block-file__button,
@@ -116,7 +117,9 @@ input[type='submit'] {
 
 /* Accent headers */
 .accent-header,
+.widgettitle ,
 .wp-block-columns .wp-block-column > .accent-header,
+.wp-block-columns .wp-block-column > .widgettitle,
 div.wpnbha .article-section-title,
 .cat-links {
 	font-size: $font__size-base;
@@ -125,7 +128,8 @@ div.wpnbha .article-section-title,
 
 .accent-header,
 .article-section-title,
-.widget-title.accent-header {
+.widget-title.accent-header,
+#secondary .widgettitle {
 	&::before {
 		display: none;
 	}
@@ -432,7 +436,8 @@ hr {
 		color: $color__text-main;
 	}
 
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		color: $color__text-main;
 		font-size: $font__size_base;
 	}

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -132,20 +132,23 @@ div.wpnbha .article-section-title,
 	&::before {
 		display: none;
 	}
+}
 
-	span {
-		align-items: center;
-		display: flex;
-		flex-wrap: wrap;
-		width: 100%;
+.accent-header span,
+.article-section-title span,
+.widget-title.accent-header span,
+#secondary .widgettitle {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
 
-		&::after {
-			background-color: currentColor;
-			content: '';
-			flex: 1 0 0.25rem;
-			height: 1px;
-			margin: 0 0 0 0.25rem;
-		}
+	&::after {
+		background-color: currentColor;
+		content: '';
+		flex: 1 0 0.25rem;
+		height: 1px;
+		margin: 0 0 0 0.25rem;
 	}
 }
 

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -117,9 +117,8 @@ input[type='submit'] {
 
 /* Accent headers */
 .accent-header,
-.widgettitle ,
+.widgettitle,
 .wp-block-columns .wp-block-column > .accent-header,
-.wp-block-columns .wp-block-column > .widgettitle,
 div.wpnbha .article-section-title,
 .cat-links {
 	font-size: $font__size-base;

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -40,7 +40,8 @@ function newspack_katharine_custom_colors_css() {
 		.cat-links a:visited,
 		.article-section-title,
 		.entry .entry-footer,
-		.accent-header {
+		.accent-header,
+		#secondary .widgettitle {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 
@@ -56,7 +57,8 @@ function newspack_katharine_custom_colors_css() {
 		.archive .page-title:before,
 		figcaption:after,
 		.wp-caption-text:after,
-		.has-highlight-menu .site-breadcrumb .wrapper > span::before {
+		.has-highlight-menu .site-breadcrumb .wrapper > span::before,
+		#secondary .widgettitle::before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
 

--- a/newspack-katharine/inc/child-typography.php
+++ b/newspack-katharine/inc/child-typography.php
@@ -38,6 +38,7 @@ function newspack_katharine_custom_typography_css() {
 			.entry-meta .entry-date,
 			.entry-meta .updated,
 			.site-footer .widget-title,
+			.site-footer .widgettitle,
 			.site-info {
 				text-transform: uppercase;
 			}

--- a/newspack-katharine/inc/child-typography.php
+++ b/newspack-katharine/inc/child-typography.php
@@ -39,7 +39,8 @@ function newspack_katharine_custom_typography_css() {
 			.entry-meta .updated,
 			.site-footer .widget-title,
 			.site-footer .widgettitle,
-			.site-info {
+			.site-info,
+			#secondary .widgettitle {
 				text-transform: uppercase;
 			}
 		';

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -445,7 +445,8 @@ hr {
 	.widget a,
 	.widget a:hover,
 	.widget a:visited,
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		color: inherit;
 	}
 }

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -51,7 +51,8 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 .accent-header,
 .article-section-title,
 .cat-links,
-.archive .page-title {
+.archive .page-title,
+#secondary .widgettitle {
 	color: $color__primary;
 
 	&::before {

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -119,12 +119,14 @@ function newspack_nelson_custom_colors_css() {
 			}
 
 			.h-sb .site-footer,
-			.site-footer .widget-title {
+			.site-footer .widget-title,
+			.site-footer .widgettitle {
 				color: ' . esc_html( $footer_color_contrast ) . ';
 			}
 
 			#colophon .site-info,
 			#colophon .site-info .widget-title,
+			#colophon .site-info .widgettitle,
 			#colophon .site-info a {
 				color: #fff;
 			}

--- a/newspack-nelson/inc/child-typography.php
+++ b/newspack-nelson/inc/child-typography.php
@@ -37,20 +37,21 @@ function newspack_nelson_custom_typography_css() {
 			.nav3,
 			.mobile-menu-toggle,
 			.accent-header,
+			.widgettitle,
 			.cat-links,
 			div.wpnbha .article-section-title,
 			.entry-meta .byline .author,
 			.tags-links a,
 			.post-edit-link,
 			.author-bio h2 span,
-			.site-footer .widget-title {
+			.site-footer .widget-title ,
+			.site-footer .widgettitle {
 				letter-spacing: 0.05em;
 				text-transform: uppercase;
 			}
 		';
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
-			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
 			.block-editor-block-list__layout .block-editor-block-list__block .cat-links {
 				letter-spacing: 0.05em;

--- a/newspack-nelson/inc/child-typography.php
+++ b/newspack-nelson/inc/child-typography.php
@@ -52,6 +52,7 @@ function newspack_nelson_custom_typography_css() {
 		';
 		$editor_css_blocks .= '
 			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
 			.block-editor-block-list__layout .block-editor-block-list__block .cat-links {
 				letter-spacing: 0.05em;

--- a/newspack-nelson/inc/child-typography.php
+++ b/newspack-nelson/inc/child-typography.php
@@ -37,7 +37,7 @@ function newspack_nelson_custom_typography_css() {
 			.nav3,
 			.mobile-menu-toggle,
 			.accent-header,
-			.widgettitle,
+			#secondary .widgettitle,
 			.cat-links,
 			div.wpnbha .article-section-title,
 			.entry-meta .byline .author,

--- a/newspack-nelson/inc/child-typography.php
+++ b/newspack-nelson/inc/child-typography.php
@@ -51,7 +51,7 @@ function newspack_nelson_custom_typography_css() {
 			}
 		';
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
 			.block-editor-block-list__layout .block-editor-block-list__block .cat-links {
 				letter-spacing: 0.05em;

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -25,6 +25,7 @@ blockquote {
 // Accent Headers
 
 .accent-header,
+.widgettitle,
 .article-section-title {
 	color: $color__text-light;
 	font-family: $font__heading;

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -25,7 +25,6 @@ blockquote {
 // Accent Headers
 
 .accent-header,
-.widgettitle,
 .article-section-title {
 	color: $color__text-light;
 	font-family: $font__heading;

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -262,6 +262,7 @@ h4,
 // Accent headers
 
 .accent-header,
+.widgettitle,
 div.wpnbha .article-section-title,
 .cat-links {
 	color: $color__text-light;
@@ -285,7 +286,8 @@ div.wpnbha .article-section-title {
 	}
 }
 
-#secondary .widget-title {
+#secondary .widget-title,
+#secondary .widgettitle {
 	color: inherit;
 	font-size: $font__size-lg;
 
@@ -548,6 +550,7 @@ blockquote {
 .mobile-sidebar,
 .site-footer {
 	.accent-header,
+	.widgettitle,
 	div.wpnbha .article-section-title {
 		color: inherit;
 	}
@@ -565,7 +568,8 @@ blockquote {
 	.widget a,
 	.widget a:hover,
 	.widget a:visited,
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		color: inherit;
 	}
 }

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -262,7 +262,7 @@ h4,
 // Accent headers
 
 .accent-header,
-.widgettitle,
+#secondary .widgettitle,
 div.wpnbha .article-section-title,
 .cat-links {
 	color: $color__text-light;

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -38,10 +38,12 @@ function newspack_sacha_custom_colors_css() {
 		.entry-meta .byline a:visited,
 		.entry .entry-meta a:hover,
 		.accent-header,
+		.widgettitle,
 		.article-section-title,
 		.cat-links,
 		.entry .entry-footer,
-		.site-footer .widget .widget-title {
+		.site-footer .widget .widget-title,
+		.site-footer .widget .widgettitle {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 
@@ -89,6 +91,7 @@ function newspack_sacha_custom_colors_css() {
 	if ( isset( $footer_color ) && '' !== $footer_color ) {
 		$theme_css .= '
 			.site-footer .widget .widget-title,
+			.site-footer .widget .widgettitle,
 			.site-info a:visited {
 				color: ' . esc_html( $footer_color_contrast ) . ';
 			}

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -38,7 +38,7 @@ function newspack_sacha_custom_colors_css() {
 		.entry-meta .byline a:visited,
 		.entry .entry-meta a:hover,
 		.accent-header,
-		.widgettitle,
+		#secondary .widgettitle,
 		.article-section-title,
 		.cat-links,
 		.entry .entry-footer,

--- a/newspack-sacha/inc/child-typography.php
+++ b/newspack-sacha/inc/child-typography.php
@@ -42,6 +42,7 @@ function newspack_sacha_custom_typography_css() {
 	if ( true === get_theme_mod( 'accent_allcaps', true ) ) {
 		$css_blocks        .= '
 			.accent-header,
+			.widgettitle,
 			.article-section-title {
 				text-transform: uppercase;
 			}

--- a/newspack-sacha/inc/child-typography.php
+++ b/newspack-sacha/inc/child-typography.php
@@ -42,7 +42,7 @@ function newspack_sacha_custom_typography_css() {
 	if ( true === get_theme_mod( 'accent_allcaps', true ) ) {
 		$css_blocks        .= '
 			.accent-header,
-			.widgettitle,
+			#secondary .widgettitle,
 			.article-section-title {
 				text-transform: uppercase;
 			}

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -72,12 +72,14 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 // Accent headers
 .accent-header,
+.widgettitle,
 .article-section-title,
 .cat-links {
 	color: $color__primary;
 }
 
 .accent-header,
+#secondary .widgettitle,
 div.wpnbha .article-section-title,
 .cat-links {
 	font-size: $font__size-xs;
@@ -86,6 +88,7 @@ div.wpnbha .article-section-title,
 }
 
 .accent-header,
+.widgettitle,
 .article-section-title > span {
 	align-items: center;
 	display: flex;
@@ -484,7 +487,8 @@ cite {
 	background-color: #f1f1f1;
 	color: $color__text-main;
 
-	.widget .widget-title {
+	.widget .widget-title,
+	.widget .widgettitle {
 		color: $color__primary;
 		font-weight: bold;
 	}

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -72,7 +72,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 // Accent headers
 .accent-header,
-.widgettitle,
+#secondary .widgettitle,
 .article-section-title,
 .cat-links {
 	color: $color__primary;
@@ -88,7 +88,7 @@ div.wpnbha .article-section-title,
 }
 
 .accent-header,
-.widgettitle,
+#secondary .widgettitle,
 .article-section-title > span {
 	align-items: center;
 	display: flex;

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -76,15 +76,14 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 .article-section-title,
 .cat-links {
 	color: $color__primary;
+	margin-bottom: $size__spacing-unit;
+	text-align: center;
 }
 
 .accent-header,
-#secondary .widgettitle,
 div.wpnbha .article-section-title,
 .cat-links {
 	font-size: $font__size-xs;
-	margin-bottom: $size__spacing-unit;
-	text-align: center;
 }
 
 .accent-header,

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -100,7 +100,8 @@ function newspack_scott_custom_colors_css() {
 		$theme_css .= '
 			#colophon,
 			#colophon .widget-title,
-			#colophon .social-navigation a {
+			#colophon .social-navigation a,
+			#colophon .widgettitle {
 				color: ' . esc_html( $footer_color_contrast ) . ';
 			}
 

--- a/newspack-scott/inc/child-typography.php
+++ b/newspack-scott/inc/child-typography.php
@@ -41,7 +41,9 @@ function newspack_scott_custom_typography_css() {
 			.page-title,
 			#secondary .widget-title,
 			.author-bio .accent-header span,
-			#colophon .widget-title {
+			#colophon .widget-title,
+			#colophon .widgettitle,
+			#secondary .widgettitle {
 				text-transform: uppercase;
 			}
 		';

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -58,7 +58,8 @@ div.wpnbha .article-section-title {
 	font-size: $font__size-sm;
 }
 
-#secondary .widget-title {
+#secondary .widget-title,
+#secondary .widgettitle {
 	font-size: $font__size-lg;
 }
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -304,6 +304,7 @@ function newspack_custom_colors_css() {
 				.site-footer a,
 				.site-footer a:hover,
 				.site-footer .widget-title,
+				.site-footer .widgettitle,
 				.site-info {
 					color: ' . esc_html( $footer_color_contrast ) . ';
 				}
@@ -344,7 +345,7 @@ function newspack_custom_colors_css() {
 					background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
 					color: ' . esc_html( $primary_color_contrast ) . ';
 				}
-				.accent-header, .article-section-title,
+				.accent-header, .widgettitle, .article-section-title,
 				.entry .entry-footer a:hover {
 					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 				}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -345,7 +345,9 @@ function newspack_custom_colors_css() {
 					background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
 					color: ' . esc_html( $primary_color_contrast ) . ';
 				}
-				.accent-header, .widgettitle, .article-section-title,
+				.accent-header,
+				#secondary .widgettitle, 
+				.article-section-title,
 				.entry .entry-footer a:hover {
 					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 				}

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -387,6 +387,7 @@ function newspack_custom_typography_css() {
 		if ( ! is_child_theme() ) {
 			$css_blocks        .= '
 				.accent-header,
+				#secondary .widgettitle,
 				.article-section-title {
 					text-transform: uppercase;
 				}

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -228,7 +228,8 @@
 		display: block;
 	}
 
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		margin: 0 0 #{0.5 * $size__spacing-unit};
 	}
 }
@@ -265,7 +266,8 @@
 		}
 	}
 
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		font-size: $font__size-md;
 	}
 }
@@ -331,7 +333,8 @@
 		}
 	}
 
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		font-size: 1.1em;
 	}
 }

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -35,7 +35,8 @@
 		}
 	}
 
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		color: $color__text-light;
 		font-size: inherit;
 	}
@@ -164,7 +165,8 @@
 			}
 		}
 
-		.widget-title {
+		.widget-title,
+		.widgettitle {
 			display: inline-block;
 			margin: 0 $size__spacing-unit 0 0;
 		}
@@ -207,7 +209,8 @@
 	}
 }
 
-#colophon .site-info .widget-title {
+#colophon .site-info .widget-title,
+#colophon .site-info .widgettitle {
 	color: inherit;
 	font-size: 1em;
 }

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -141,7 +141,8 @@
 		}
 	}
 
-	.widget-title {
+	.widget-title,
+	.widgettitle {
 		font-size: $font__size-md;
 	}
 }

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -1,6 +1,7 @@
 /* Headers */
 
 .accent-header,
+#secondary .widgettitle,
 .article-section-title {
 	border-bottom: 4px solid $color__border;
 	color: $color__primary;

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -5,8 +5,12 @@
 .article-section-title {
 	border-bottom: 4px solid $color__border;
 	color: $color__primary;
-	font-size: $font__size-sm;
 	padding-bottom: #{$size__spacing-unit * 0.33};
+}
+
+.accent-header,
+.article-section-title {
+	font-size: $font__size-sm;
 }
 
 .accent-header,

--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -205,7 +205,8 @@ h6 {
 	text-transform: none;
 }
 
-.accent-header {
+.accent-header,
+#secondary .widgettitle {
 	margin-bottom: 0.5em;
 
 	+ * {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
